### PR TITLE
Fix LinkKey.from_save

### DIFF
--- a/scraper_class.py
+++ b/scraper_class.py
@@ -1,0 +1,39 @@
+import re
+import requests
+from collections import deque
+from scripts.base_url import base_url
+
+class Scraper:
+    def __init__(self, url):
+        self.new_urls = deque([url])
+        self.email_dict = {}
+        self.url_counter = {}
+        self.queue_counter = {}
+        self.current_url = None
+        self.response = None
+
+    def set_current_url(self):
+        self.current_url = self.new_urls.popleft()
+        base = self.get_current_base_url()
+        self.email_dict.setdefault(base, [])
+        self.url_counter.setdefault(base, 0)
+        self.queue_counter.setdefault(base, 0)
+
+    def get_current_base_url(self):
+        return base_url(self.current_url)
+
+    def set_response_with_html(self):
+        r = requests.get(self.current_url, timeout=5)
+        self.response = r.text
+
+    def get_email_from_response(self):
+        if not self.response:
+            return
+        new_emails = list(set(re.findall(r"[a-z0-9\.\-+_]+@[a-z0-9\.\-+_]+\.[a-z]+", self.response, re.I)))
+        if new_emails:
+            base = self.get_current_base_url()
+            self.email_dict[base].extend(new_emails)
+
+    def print_emails(self):
+        for base, emails in self.email_dict.items():
+            print(base, emails)

--- a/scripts/link_key.py
+++ b/scripts/link_key.py
@@ -88,8 +88,11 @@ class LinkKey(ScrapeReg):
             debug_dict = save_dict.get('debug_dict')
             buggy_url_list = save_dict.get('buggy_url_list')
 
-            # create a ScrapeReg object
-            url = ScrapeReg(new_urls, regex)
+            # recreate a LinkKey object so the calling code receives the
+            # correct type.  Returning the base ``ScrapeReg`` class here
+            # prevented access to ``LinkKey`` specific behaviour when
+            # resuming a session.
+            url = LinkKey(new_urls, regex)
             url.session_name = session_name
             url.result_dict = result_dict
             url.response = response


### PR DESCRIPTION
## Summary
- fix `LinkKey.from_save` to instantiate `LinkKey` instead of `ScrapeReg`
- add minimal `scraper_class` module required by tests

## Testing
- `python -m pip install -r requirements.txt`
- `PYTHONPATH=. pytest tests/test_scraper_class.py::MyTestCase::test_get_email_with_html_parser -q` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_683f3c25e4b0832c839aa868d8d3aa90